### PR TITLE
修复编辑监控策略时用户只显示ID，不显示用户信息

### DIFF
--- a/mon-web/src/pages/Strategy/SettingFields.jsx
+++ b/mon-web/src/pages/Strategy/SettingFields.jsx
@@ -379,6 +379,8 @@ class SettingFields extends Component {
                 loading={this.state.notifyDataLoading}
                 notifyGroupData={this.state.notifyGroupData}
                 notifyUserData={this.state.notifyUserData}
+                notifyGroupDetail={this.props.initialValues.action.notify_group_detail}
+                notifyUserDetail={this.props.initialValues.action.notify_user_detail}
                 // eslint-disable-next-line react/jsx-no-bind
                 fetchNotifyData={this.fetchNotifyData.bind(this)}
               />,

--- a/mon-web/src/pages/Strategy/SettingFields/Actions/index.jsx
+++ b/mon-web/src/pages/Strategy/SettingFields/Actions/index.jsx
@@ -25,8 +25,15 @@ export default class Actions extends Component {
     notifyUserLoading: PropTypes.bool,
     notifyGroupData: PropTypes.array,
     notifyUserData: PropTypes.array,
+    notifyGroupDetail: PropTypes.array,
+    notifyUserDetail: PropTypes.array,
     fetchNotifyData: PropTypes.func.isRequired,
   };
+
+  componentWillMount(){
+    this.props.notifyUserData.push(...this.props.notifyUserDetail)
+    this.props.notifyGroupData.push(...this.props.notifyGroupDetail)
+  }
 
   static defaultProps = {
     readOnly: false,
@@ -34,6 +41,8 @@ export default class Actions extends Component {
     notifyUserLoading: false,
     notifyGroupData: [],
     notifyUserData: [],
+    notifyGroupDetail: [],
+    notifyUserDetail: [],
   };
 
   handleConvergeChange = (index, val) => {

--- a/mon-web/src/pages/Strategy/utils.jsx
+++ b/mon-web/src/pages/Strategy/utils.jsx
@@ -8,6 +8,8 @@ export function normalizeFormData(values) {
       recovery_notify: values.recovery_notify,
       notify_group: values.notify_group || undefined,
       notify_user: values.notify_user || undefined,
+      notify_group_detail: values.notify_group_detail || [],
+      notify_user_detail: values.notify_user_detail || [],
       callback: values.callback,
     },
     period_time: {


### PR DESCRIPTION
编辑监控策略时，如果用户不在首次加载的50名用户中，用户会只显示一个ID，不显示用户信息。
![image](https://user-images.githubusercontent.com/22955185/131821630-7893bc63-c857-4954-9bd4-1603c17a43dc.png)
