### PR TITLE
修复编辑监控策略时用户只显示ID，不显示用户信息

### DIFF
--- a/mon-web/src/pages/Strategy/SettingFields.jsx
+++ b/mon-web/src/pages/Strategy/SettingFields.jsx
@@ -45,14 +45,17 @@ class SettingFields extends Component {
     this.fetchNotifyData = _.throttle(this.fetchNotifyData, 300);
   }
 
-  componentDidMount() {
-    this.fetchTreeData();
-    this.fetchMetrics.call(this, this.props.initialValues.category);
-    this.fetchTagkvs(this.props.initialValues.exprs);
+  componentWillMount() {
     if (this.props.initialValues.action){
       this.setState({notifyGroupDetail:this.props.initialValues.action.notify_group_detail})
       this.setState({notifyUserDetail:this.props.initialValues.action.notify_user_detail})
     }
+  }
+
+  componentDidMount() {
+    this.fetchTreeData();
+    this.fetchMetrics.call(this, this.props.initialValues.category);
+    this.fetchTagkvs(this.props.initialValues.exprs);
     // this.fetchNotifyData({
     //   ids: _.get(this.props.initialValues, 'notify_group')
     // }, {

--- a/mon-web/src/pages/Strategy/SettingFields.jsx
+++ b/mon-web/src/pages/Strategy/SettingFields.jsx
@@ -38,6 +38,8 @@ class SettingFields extends Component {
       notifyDataLoading: false,
       notifyGroupData: [],
       notifyUserData: [],
+      notifyGroupDetail: [],
+      notifyUserDetail: [],
       advanced: false,
     };
     this.fetchNotifyData = _.throttle(this.fetchNotifyData, 300);
@@ -47,6 +49,10 @@ class SettingFields extends Component {
     this.fetchTreeData();
     this.fetchMetrics.call(this, this.props.initialValues.category);
     this.fetchTagkvs(this.props.initialValues.exprs);
+    if (this.props.initialValues.action){
+      this.setState({notifyGroupDetail:this.props.initialValues.action.notify_group_detail})
+      this.setState({notifyUserDetail:this.props.initialValues.action.notify_user_detail})
+    }
     // this.fetchNotifyData({
     //   ids: _.get(this.props.initialValues, 'notify_group')
     // }, {
@@ -379,6 +385,8 @@ class SettingFields extends Component {
                 loading={this.state.notifyDataLoading}
                 notifyGroupData={this.state.notifyGroupData}
                 notifyUserData={this.state.notifyUserData}
+                notifyUserDetail={this.state.notifyUserDetail}
+                notifyGroupDetail={this.state.notifyGroupDetail}
                 // eslint-disable-next-line react/jsx-no-bind
                 fetchNotifyData={this.fetchNotifyData.bind(this)}
               />,

--- a/mon-web/src/pages/Strategy/SettingFields/Actions/index.jsx
+++ b/mon-web/src/pages/Strategy/SettingFields/Actions/index.jsx
@@ -25,8 +25,15 @@ export default class Actions extends Component {
     notifyUserLoading: PropTypes.bool,
     notifyGroupData: PropTypes.array,
     notifyUserData: PropTypes.array,
+    notifyGroupDetail: PropTypes.array,
+    notifyUserDetail: PropTypes.array,
     fetchNotifyData: PropTypes.func.isRequired,
   };
+
+  componentWillMount(){
+    this.props.notifyUserData.push(...this.props.notifyUserDetail)
+    this.props.notifyGroupData.push(...this.props.notifyGroupDetail)
+  }
 
   static defaultProps = {
     readOnly: false,
@@ -34,6 +41,8 @@ export default class Actions extends Component {
     notifyUserLoading: false,
     notifyGroupData: [],
     notifyUserData: [],
+    notifyGroupDetail: [],
+    notifyUserDetail: [],
   };
 
   handleConvergeChange = (index, val) => {

--- a/mon-web/src/pages/Strategy/utils.jsx
+++ b/mon-web/src/pages/Strategy/utils.jsx
@@ -8,6 +8,8 @@ export function normalizeFormData(values) {
       recovery_notify: values.recovery_notify,
       notify_group: values.notify_group || undefined,
       notify_user: values.notify_user || undefined,
+      notify_group_detail: values.notify_group_detail || [],
+      notify_user_detail: values.notify_user_detail || [],
       callback: values.callback,
     },
     period_time: {


### PR DESCRIPTION
编辑监控策略时，如果用户不在首次加载的50名用户中，用户会只显示一个ID，不显示用户信息。
![image](https://user-images.githubusercontent.com/22955185/131821656-639964bd-299b-4d99-8ad4-9f510f46ca4e.png)
